### PR TITLE
Update copyfail_mitigation module

### DIFF
--- a/copyfail_mitigation/README.md
+++ b/copyfail_mitigation/README.md
@@ -11,20 +11,17 @@ The `copyfail_mitigation` module allows operators to mitigate the [Copy Fail vul
 > section of the required management Cluster release in the
 > [MOSK documentation: Release notes](https://docs.mirantis.com/mosk/latest/release-notes.html).
 
-# Version 1.0.0 (latest)
+# Version 1.1.0 (latest)
 
 The `copyfail_mitigation` module is designed to mitigate the following vulnerability: [Local privilege escalation (Linux kernel "Copy-Fail", CVE-2026-31431) affects Mirantis OpenStack for Kubernetes (MOSK) cluster nodes when AF_ALG/AEAD is exposed](https://github.com/Mirantis/security/blob/main/advisories/0015.md).
 
 The module accepts the following input parameters:
 
-- `mitigate`: Boolean. Optional (defaults to `false`). Set to `true` to mitigate Copy-Fail on the host.
 - `revert`: Boolean. Optional (defaults to `false`). Set to `true` to revert the mitigation and restore original kernel settings.
-
-The `mitigate` and `revert` parameters cannot be set to `true` simultaneously.
 
 ## Mitigation workflow
 
-When `mitigate` is set to `true`, the module performs the following actions:
+When `revert` is NOT set to `true`, the module performs the following actions:
 
 1. Creates `/etc/modprobe.d/blacklist-algif_aead.conf` to block loading of the `algif_aead` kernel module.
 2. Verifies whether `algif_aead` is currently loaded.
@@ -34,7 +31,6 @@ If the kernel module is loaded on the host, the `copyfail_mitigation` module als
 1. Attempts to unload `algif_aead` from the live kernel memory space.
 2. Flushes the kernel page cache after a successful unload to purge any volatile in-memory exploitation.
 3. Creates a reboot request.
-4. Creates a local system marker file to ensure that `revert` can restore the original configuration if needed.
 
 ## Rebooting the hosts
 After applying the mitigation, you must perform a reboot of affected hosts as soon as possible.
@@ -42,15 +38,12 @@ Plan a maintenance window and use the official Mirantis procedure on how to [Per
 
 ## Reversion workflow
 
-When `revert` is set to `true`, the `copyfail_mitigation` module safely rolls back changes:
-
-1. Removes `/etc/modprobe.d/blacklist-algif_aead.conf` to allow loading of the `algif_aead` kernel module.
-2. Inspects the local system marker file to verify whether the module was active prior to the initial mitigation.
-   And if so, reloads the `algif_aead` module into the active kernel and tidies up tracking paths.
+When the `revert` parameter is set to `true`, the `copyfail_mitigation` module automatically removes `/etc/modprobe.d/blacklist-algif_aead.conf`. This action unblocks and permits the loading of the `algif_aead` kernel module.
+Once the HOC has been successfully applied with `revert: true` parameter, you can safely delete the HOC object using `kubectl delete hoc` command.
 
 # Configuration examples
 
-Example of a `HostOSConfiguration` custom resource for the `copyfail_mitigation` module version 1.0.0:
+Example of a `HostOSConfiguration` custom resource for the `copyfail_mitigation` module version 1.1.0 for applying the mitigation:
 
 ```yaml
 apiVersion: kaas.mirantis.com/v1alpha1
@@ -61,13 +54,30 @@ metadata:
 spec:
   configs:
   - module: copyfail_mitigation
-    moduleVersion: 1.0.0
-    values:
-      mitigate: true
-      revert: false
+    moduleVersion: 1.1.0
+    values: {}
   machineSelector:
     matchLabels:
-      day2-copyfail-mitigation-label: 'true'
+      copyfail-mitigation-label: 'true'
+```
+
+Example of a `HostOSConfiguration` custom resource for the `copyfail_mitigation` module version 1.1.0 for reverting the mitigation:
+
+```yaml
+apiVersion: kaas.mirantis.com/v1alpha1
+kind: HostOSConfiguration
+metadata:
+  name: copyfail-mitigation
+  namespace: default
+spec:
+  configs:
+  - module: copyfail_mitigation
+    moduleVersion: 1.1.0
+    values:
+      revert: true
+  machineSelector:
+    matchLabels:
+      copyfail-mitigation-label: 'true'
 ```
 
 ---

--- a/copyfail_mitigation/main.yaml
+++ b/copyfail_mitigation/main.yaml
@@ -5,11 +5,9 @@
   tasks:
     - name: Apply Copy Fail Mitigation
       when:
-      - values.mitigate is defined
-      - values.mitigate
       - not (values.revert | default(False))
       block:
-        - name: Create persistent modprobe blacklist configuration
+        - name: Persistently block aglif_aead kernel module
           ansible.builtin.copy:
             dest: /etc/modprobe.d/blacklist-algif_aead.conf
             content: |
@@ -31,25 +29,15 @@
           when:
             - (unload_module.changed or unload_module.failed)
           block:
-          - name: Request a reboot
-            ansible.builtin.command: /bin/true
-            notify: "request reboot"
-            changed_when: true
-
           - name: Flush page cache to purge volatile in-memory exploitation
             ansible.builtin.shell: sync; echo 3 > /proc/sys/vm/drop_caches
             when:
               - unload_module.changed
 
-          - name: Create /root/.ansible/copyfail_mitigation
-            ansible.builtin.file:
-              path: /root/.ansible/copyfail_mitigation
-              state: directory
-
-          - name: Create /root/.ansible/copyfail_mitigation/load_algif_aead marker file
-            ansible.builtin.file:
-              path: /root/.ansible/copyfail_mitigation/load_algif_aead
-              state: touch
+          - name: Request a reboot
+            ansible.builtin.command: /bin/true
+            notify: "request reboot"
+            changed_when: true
 
     - name: Revert Copy Fail Mitigation
       when:
@@ -61,24 +49,6 @@
             path: /etc/modprobe.d/blacklist-algif_aead.conf
             state: absent
           register: remove_blacklist
-
-        - name: Check if algif_aead was loaded before HOC was executed first time
-          ansible.builtin.stat:
-            path: "/root/.ansible/copyfail_mitigation/load_algif_aead"
-          register: mitigation_marker
-
-        - name: Restore module to pre-mitigation state
-          when: mitigation_marker.stat.exists
-          block:
-          - name: Load the algif_aead module back into the live kernel
-            ansible.builtin.modprobe:
-              name: algif_aead
-              state: present
-
-          - name: Delete /root/.ansible/copyfail_mitigation
-            ansible.builtin.file:
-              path: /root/.ansible/copyfail_mitigation
-              state: absent
 
   handlers:
     - name: Create /run/day2

--- a/copyfail_mitigation/metadata.yaml
+++ b/copyfail_mitigation/metadata.yaml
@@ -1,6 +1,6 @@
 name: copyfail_mitigation
 description: 'Module mitigating CVE-2026-31431 "Copy-Fail"'
-version: 1.0.0
+version: 1.1.0
 valuesJsonSchema: schema.json
 docURL: https://github.com/Mirantis/mosk-hocm-contrib/blob/main/copyfail_mitigation/README.md
 playbook: main.yaml

--- a/copyfail_mitigation/schema.json
+++ b/copyfail_mitigation/schema.json
@@ -2,23 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "mitigate": {
-      "type": "boolean"
-    },
     "revert": {
       "type": "boolean"
     }
   },
-  "additionalProperties": false,
-  "allOf": [
-    {
-      "not": {
-        "properties": {
-          "mitigate": { "const": true },
-          "revert": { "const": true }
-        },
-        "required": ["mitigate", "revert"]
-      }
-    }
-  ]
+  "additionalProperties": false
 }


### PR DESCRIPTION
- default behavior is now "if not 'revert: true': do mitigation; else do revert"
- remove re-loading of algif_aead kernel module after revert
- minor doc changes